### PR TITLE
Add quoted_tweet do tweet events

### DIFF
--- a/lib/twitter/streaming/event.rb
+++ b/lib/twitter/streaming/event.rb
@@ -8,7 +8,7 @@ module Twitter
       ].freeze
 
       TWEET_EVENTS = [
-        :favorite, :unfavorite
+        :favorite, :unfavorite, :quoted_tweet
       ].freeze
 
       attr_reader :name, :source, :target, :target_object


### PR DESCRIPTION
This makes it possible to get the Tweet object from a :quoted_tweet event, which isn't possible currently.